### PR TITLE
Fix spelling and grammar in comments

### DIFF
--- a/Development/Create_the_MarkdownHelpers_Package.OLD.R
+++ b/Development/Create_the_MarkdownHelpers_Package.OLD.R
@@ -49,7 +49,7 @@ if (!dir.exists(RepositoryDir)) {
 }
 
 
-# go and write fun's ------------------------------------------------------------------------
+# go and write functions ------------------------------------------------------------------------
 # file.edit(package.FnP)
 
 # Create Roxygen Skeletons ------------------------

--- a/Development/Create_the_MarkdownHelpers_Package.R
+++ b/Development/Create_the_MarkdownHelpers_Package.R
@@ -52,7 +52,7 @@ styler::style_pkg(repository.dir)
 PackageTools::extract_package_dependencies(repository.dir)
 # I have a list of functions where some are not properly separated at the bottom. Answer in text, not code.
 # I need the following:
-#   1. Generate a simple,unique, sorted list of function names, one function per line.
+#   1. Generate a simple, unique, sorted list of function names, one function per line.
 # 2. Identify the packages that contain these functions and provide a list of the corresponding packages for each function. Also make an R vector of the package names.
 # 3. Acknowledge that some functions may not have an easily identifiable package.
 

--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -60,7 +60,7 @@ irequire <- function(package) {
     print("Loading package:")
     require(package = package_, character.only = TRUE)
   }
-} # install package if cannot be loaded
+} # install package if it cannot be loaded
 
 
 # ______________________________________________________________________________________________________________________________
@@ -184,7 +184,7 @@ lookup <- function(needle, haystack, exact = TRUE, report = FALSE) { # Awesome p
 #'
 #' @export
 
-combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # combine matrices by rownames intersect
+combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # combine matrices by row name intersection
   rn1 <- rownames(matrix1)
   rn2 <- rownames(matrix2)
   idx <- intersect(rn1, rn2)
@@ -354,7 +354,7 @@ md.image.linker <- function(fname_wo_ext, OutDir_ = ww.set.OutDir()) {
     } else {
       if (exists("b.Subdirname") && !b.Subdirname == FALSE) {
         fname_wo_ext <- paste0(b.Subdirname, "/", fname_wo_ext)
-      } # set only if b.Subdirname is defined, it is not FALSE.
+      } # set only if b.Subdirname is defined and not FALSE.
       llogit(kollapse("![", fn, "]", "(", fname_wo_ext, ".png)", print = FALSE))
     }
   } else {
@@ -438,7 +438,7 @@ md.import <- function(from.file, to.file = ww.set.path_of_report()) {
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
 md.LogSettingsFromList <- function(parameterlist,
                                    maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -468,7 +468,7 @@ md.List2Table <- function(parameterlist,
                           title = "List elements",
                           colname2 = "Value",
                           maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -1195,7 +1195,7 @@ ww.autoPlotName <- function(name = NULL) {
 #' @export
 
 ww.assign_to_global <- function(name, value, pos = 1, max_print = 5, verbose = TRUE) {
-  if (verbose) Stringendo::iprint(name, "defined as:", head(value, max_print)) # , "is a new global environment variable"
+  if (verbose) Stringendo::iprint(name, "defined as:", head(value, max_print)) # "is a new global environment variable"
   assign(name, value, envir = as.environment(pos))
 }
 
@@ -1311,7 +1311,7 @@ wcolorize <- function(vector = c(1, 1, 1:6),
   COLZ <- CodeAndRoll2::as.numeric.wNames.factor(vector) # if basic numbers
   if (randomize) {
     COLZ <- sample(COLZ)
-  } # if randomise
+  } # if randomize
   if (RColorBrewerSet != FALSE) {
     COLZ <- RColorBrewer::brewer.pal(NrCol, name = RColorBrewerSet)[CodeAndRoll2::as.numeric.wNames.factor(vector)]
   } else {

--- a/R/MarkdownHelpers.R
+++ b/R/MarkdownHelpers.R
@@ -44,7 +44,7 @@ irequire <- function(package) {
     print("Loading package:")
     require(package = package_, character.only = TRUE)
   }
-} # install package if cannot be loaded
+} # install package if it cannot be loaded
 
 
 # ______________________________________________________________________________________________________________________________
@@ -170,7 +170,7 @@ lookup <- function(needle, haystack, exact = TRUE, report = FALSE) { # Awesome p
 #'
 #' @export
 
-combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # combine matrices by rownames intersect
+combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # combine matrices by row name intersection
   rn1 <- rownames(matrix1)
   rn2 <- rownames(matrix2)
   idx <- intersect(rn1, rn2)
@@ -341,7 +341,7 @@ md.image.linker <- function(fname_wo_ext, OutDir_ = ww.set.OutDir()) {
     } else {
       if (exists("b.Subdirname") && !b.Subdirname == FALSE) {
         fname_wo_ext <- paste0(b.Subdirname, "/", fname_wo_ext)
-      } # set only if b.Subdirname is defined, it is not FALSE.
+      } # set only if b.Subdirname is defined and not FALSE.
       llogit(kollapse("![", fn, "]", "(", fname_wo_ext, ".png)", print = FALSE))
     }
   } else {
@@ -425,7 +425,7 @@ md.import <- function(from.file, to.file = ww.set.path_of_report()) {
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
 md.LogSettingsFromList <- function(parameterlist,
                                    maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -455,7 +455,7 @@ md.List2Table <- function(parameterlist,
                           title = "List elements",
                           colname2 = "Value",
                           maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -1196,7 +1196,7 @@ ww.autoPlotName <- function(name = NULL) {
 
 ww.assign_to_global <- function(name, value, pos = 1, max_print = 5, verbose = TRUE) {
   if (verbose) {
-    Stringendo::iprint(name, "defined as:") # , "is a new global environment variable"
+    Stringendo::iprint(name, "defined as:") # "is a new global environment variable"
     print(utils::head(value, max_print))
   }
   assign(name, value, envir = as.environment(pos))
@@ -1319,7 +1319,7 @@ wcolorize <- function(vector = c(1, 1, 1:6),
   COLZ <- CodeAndRoll2::as.numeric.wNames.factor(vector) # if basic numbers
   if (randomize) {
     COLZ <- sample(COLZ)
-  } # if randomise
+  } # if randomize
   if (RColorBrewerSet != FALSE) {
     COLZ <- RColorBrewer::brewer.pal(NrCol, name = RColorBrewerSet)[CodeAndRoll2::as.numeric.wNames.factor(vector)]
   } else {


### PR DESCRIPTION
## Summary
- Correct spelling and grammar in inline comments across package and development scripts.

## Testing
- `R -q -e "devtools::test()"` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933182f9c0832cb12caad137a3c1e8