### PR TITLE
fix: correct spelling mistakes

### DIFF
--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -216,7 +216,7 @@ combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # c
 #'
 #' @description Check if a variable name is defined, and if so, does the path (to a file) stored in that
 #'  variable points to an existing directory?
-#' @param path A variable name that might not exist and might point to a non-existent direcotry.
+#' @param path A variable name that might not exist and might point to a non-existent directory.
 #' @param alt.message Alternative message if the variable + path does not exist. FALSE or string.
 #' @export
 #' @examples ww.variable.and.path.exists(path = B, alt.message = "Hello, your path/var does not exist.")
@@ -432,13 +432,13 @@ md.import <- function(from.file, to.file = ww.set.path_of_report()) {
 #'
 #' @description Log the parameters & settings used in the script and stored in a list, in a table format
 #'  in the report.
-#' @param parameterlist List of Paramters
+#' @param parameterlist List of Parameters
 #' @param maxlen Maximum length of entries in a parameter list element
 #' @export
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
 md.LogSettingsFromList <- function(parameterlist,
                                    maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -460,7 +460,7 @@ md.LogSettingsFromList <- function(parameterlist,
 #' named (col1) list, in a table format in the report.
 #' @param title Title of the table.
 #' @param colname2 Name of the 2nd column.
-#' @param parameterlist List of Paramters.
+#' @param parameterlist List of Parameters.
 #' @param maxlen Maximum length of entries in a parameter list element,.
 #' @export
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
@@ -468,7 +468,7 @@ md.List2Table <- function(parameterlist,
                           title = "List elements",
                           colname2 = "Value",
                           maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -662,7 +662,7 @@ md.LinkTable <- function(tableOfLinkswRownames) {
 # ______________________________________________________________________________________________________________________________
 #' @title md.import.table
 #'
-#' @description Import a table (.csv, or tab seprated values, .tsv file) and write it
+#' @description Import a table (.csv, or tab separated values, .tsv file) and write it
 #' in markdown format to the report.
 #' @param from.file.table  The *.tsv file to be appended  as table at
 #' the (current) last line of the report.
@@ -982,7 +982,7 @@ ww.FnP_parser <- function(fname, ext_wo_dot) {
 #'
 #' @description Check if a variable name is defined, and if so, does the path (to a file) stored in that
 #'  variable points to an existing directory?
-#' @param path A variable name that might not exist and might point to a non-existent direcotry.
+#' @param path A variable name that might not exist and might point to a non-existent directory.
 #' @param alt.message Alternative message if the variable + path does not exist. FALSE or string.
 #' @importFrom Stringendo iprint
 #' @export
@@ -1185,11 +1185,11 @@ ww.autoPlotName <- function(name = NULL) {
 #'
 #' @description A function loading results to the global environment.
 #' Source: https://stackoverflow.com/questions/28180989/
-#' @param name Name of the global variabe to be assigned
-#' @param value Value of the global variabe to be assigned
+#' @param name Name of the global variable to be assigned
+#' @param value Value of the global variable to be assigned
 #' @param verbose Print directory to screen? Default: TRUE
 #' @param max_print Print max this many elements, Default: 10
-#' @param pos defaults to 1 which equals an assingment to global environment
+#' @param pos defaults to 1 which equals an assignment to global environment
 #' @importFrom Stringendo iprint
 #'
 #' @export
@@ -1274,7 +1274,7 @@ color_check <- function(..., incrBottMarginBy = 0, savefile = FALSE) {
 #'
 #' @description Generate color palettes. Input: a vector with categories, can be numbers or strings.
 #' Handles repeating values. Output: color vector of equal length as input.
-#' Optionally it can ouput a list where an extra element lists the
+#' Optionally it can output a list where an extra element lists the
 #' categories (simply using unique would remove the names). See example.
 #' Some color scale depend on packages "colorRamps", or "gplots".
 #'
@@ -1373,7 +1373,7 @@ filter_survival_length <- function(length_new, length_old, prepend = "") { # Par
 #' @title ww.set.file.extension
 #'
 #' @description Internal function. Sets file extension for ggExpress plotting functions.
-#' @param global_setting global file extension setting stored in a global variable. Detault: 'b.def.ext'
+#' @param global_setting global file extension setting stored in a global variable. Default: 'b.def.ext'
 #' @param default Default file extension: png
 #' @param also_pdf Save plot in both png and pdf formats.
 #' @export

--- a/R/MarkdownHelpers.R
+++ b/R/MarkdownHelpers.R
@@ -202,7 +202,7 @@ combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # c
 #'
 #' @description Check if a variable name is defined, and if so, does the path (to a file) stored in that
 #'  variable points to an existing directory?
-#' @param path A variable name that might not exist and might point to a non-existent direcotry.
+#' @param path A variable name that might not exist and might point to a non-existent directory.
 #' @param alt.message Alternative message if the variable + path does not exist. FALSE or string.
 #' @export
 #' @examples ww.variable.and.path.exists(path = B, alt.message = "Hello, your path/var does not exist.")
@@ -419,13 +419,13 @@ md.import <- function(from.file, to.file = ww.set.path_of_report()) {
 #'
 #' @description Log the parameters & settings used in the script and stored in a list, in a table format
 #'  in the report.
-#' @param parameterlist List of Paramters
+#' @param parameterlist List of Parameters
 #' @param maxlen Maximum length of entries in a parameter list element
 #' @export
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
 md.LogSettingsFromList <- function(parameterlist,
                                    maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -447,7 +447,7 @@ md.LogSettingsFromList <- function(parameterlist,
 #' named (col1) list, in a table format in the report.
 #' @param title Title of the table.
 #' @param colname2 Name of the 2nd column.
-#' @param parameterlist List of Paramters.
+#' @param parameterlist List of Parameters.
 #' @param maxlen Maximum length of entries in a parameter list element,.
 #' @export
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
@@ -455,7 +455,7 @@ md.List2Table <- function(parameterlist,
                           title = "List elements",
                           colname2 = "Value",
                           maxlen = 20) {
-  LZ <- unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ <- unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG <- names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen) {
@@ -656,7 +656,7 @@ md.LinkTable <- function(tableOfLinkswRownames) {
 # ______________________________________________________________________________________________________________________________
 #' @title md.import.table
 #'
-#' @description Import a table (.csv, or tab seprated values, .tsv file) and write it
+#' @description Import a table (.csv, or tab separated values, .tsv file) and write it
 #' in markdown format to the report.
 #' @param from.file.table  The *.tsv file to be appended  as table at
 #' the (current) last line of the report.
@@ -977,7 +977,7 @@ ww.FnP_parser <- function(fname, ext_wo_dot = NULL) {
 #'
 #' @description Check if a variable name is defined, and if so, does the path (to a file) stored in that
 #'  variable points to an existing directory?
-#' @param path A variable name that might not exist and might point to a non-existent direcotry.
+#' @param path A variable name that might not exist and might point to a non-existent directory.
 #' @param alt.message Alternative message if the variable + path does not exist. FALSE or string.
 #' @importFrom Stringendo iprint
 #' @export
@@ -1181,11 +1181,11 @@ ww.autoPlotName <- function(name = NULL) {
 #'
 #' @description A function loading results to the global environment.
 #' Source: https://stackoverflow.com/questions/28180989/
-#' @param name Name of the global variabe to be assigned
-#' @param value Value of the global variabe to be assigned
+#' @param name Name of the global variable to be assigned
+#' @param value Value of the global variable to be assigned
 #' @param verbose Print directory to screen? Default: TRUE
 #' @param max_print Print max this many elements, Default: 10
-#' @param pos defaults to 1 which equals an assingment to global environment
+#' @param pos defaults to 1 which equals an assignment to global environment
 #'
 #' @importFrom Stringendo iprint
 #' @examples ww.assign_to_global("myvar", 1:10) # Assign to the global environment
@@ -1282,7 +1282,7 @@ color_check <- function(..., incrBottMarginBy = 0, savefile = FALSE) {
 #'
 #' @description Generate color palettes. Input: a vector with categories, can be numbers or strings.
 #' Handles repeating values. Output: color vector of equal length as input.
-#' Optionally it can ouput a list where an extra element lists the
+#' Optionally it can output a list where an extra element lists the
 #' categories (simply using unique would remove the names). See example.
 #' Some color scale depend on packages "colorRamps", or "gplots".
 #'
@@ -1379,7 +1379,7 @@ filter_survival_length <- function(length_new, length_old, prepend = "") { # Par
 #' @title ww.set.file.extension
 #'
 #' @description Internal function. Sets file extension for ggExpress plotting functions.
-#' @param global_setting global file extension setting stored in a global variable. Detault: 'b.def.ext'
+#' @param global_setting global file extension setting stored in a global variable. Default: 'b.def.ext'
 #' @param default Default file extension: png
 #' @param also_pdf Save plot in both png and pdf formats.
 #' @export

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ md.tableWriter.VEC.w.names. Take an R vector with names, parse a markdown table 
 md.LinkTable. Take a dataframe where every entry is a string containing an html link, parse and write out.   a properly formatted markdown table.
 
 - #### 19 `md.import.table()`
-md.import.table. Import a table (.csv, or tab seprated values, .tsv file) and write it  in markdown format to the report.
+md.import.table. Import a table (.csv, or tab separated values, .tsv file) and write it  in markdown format to the report.
 
 - #### 20 `filter_HP()`
 filter_HP. Filter values that fall between above high-pass-threshold (X >). 
@@ -232,7 +232,7 @@ jjpegA4. Setup an A4 size jpeg.
 color_check. Display the colors encoded by the numbers / color-ID-s you pass on to this function
 
 - #### 37 `wcolorize()`
-wcolorize. Generate color palettes. Input: a vector with categories, can be numbers or strings.  Handles repeating values. Output: color vector of equal length as input.  Optionally it can ouput a list where an extra element lists the  categories (simply using unique would remove the names). See example.  Some color scale depend on packages "colorRamps", or "gplots". 
+wcolorize. Generate color palettes. Input: a vector with categories, can be numbers or strings.  Handles repeating values. Output: color vector of equal length as input.  Optionally it can output a list where an extra element lists the  categories (simply using unique would remove the names). See example.  Some color scale depend on packages "colorRamps", or "gplots".
 
 - #### 38 `filter_survival_length()`
 filter_survival_length. Parse a sentence reporting the % of filter survival.

--- a/man/md.List2Table.Rd
+++ b/man/md.List2Table.Rd
@@ -12,7 +12,7 @@ md.List2Table(
 )
 }
 \arguments{
-\item{parameterlist}{List of Paramters.}
+\item{parameterlist}{List of Parameters.}
 
 \item{title}{Title of the table.}
 

--- a/man/md.LogSettingsFromList.Rd
+++ b/man/md.LogSettingsFromList.Rd
@@ -7,7 +7,7 @@
 md.LogSettingsFromList(parameterlist, maxlen = 20)
 }
 \arguments{
-\item{parameterlist}{List of Paramters}
+\item{parameterlist}{List of Parameters}
 
 \item{maxlen}{Maximum length of entries in a parameter list element}
 }

--- a/man/md.import.table.Rd
+++ b/man/md.import.table.Rd
@@ -29,7 +29,7 @@ the (current) last line of the report.}
 which is set by the "setup_MarkdownReports" function.}
 }
 \description{
-Import a table (.csv, or tab seprated values, .tsv file) and write it
+Import a table (.csv, or tab separated values, .tsv file) and write it
 in markdown format to the report.
 }
 \examples{

--- a/man/wcolorize.Rd
+++ b/man/wcolorize.Rd
@@ -32,7 +32,7 @@ or "rich" for gplots::rich.colors, or  "matlab" for colorRamps::matlab.like.}
 \description{
 Generate color palettes. Input: a vector with categories, can be numbers or strings.
 Handles repeating values. Output: color vector of equal length as input.
-Optionally it can ouput a list where an extra element lists the
+Optionally it can output a list where an extra element lists the
 categories (simply using unique would remove the names). See example.
 Some color scale depend on packages "colorRamps", or "gplots".
 }

--- a/man/ww.assign_to_global.Rd
+++ b/man/ww.assign_to_global.Rd
@@ -7,11 +7,11 @@
 ww.assign_to_global(name, value, pos = 1, max_print = 5, verbose = TRUE)
 }
 \arguments{
-\item{name}{Name of the global variabe to be assigned}
+\item{name}{Name of the global variable to be assigned}
 
-\item{value}{Value of the global variabe to be assigned}
+\item{value}{Value of the global variable to be assigned}
 
-\item{pos}{defaults to 1 which equals an assingment to global environment}
+\item{pos}{defaults to 1 which equals an assignment to global environment}
 
 \item{max_print}{Print max this many elements, Default: 10}
 

--- a/man/ww.set.file.extension.Rd
+++ b/man/ww.set.file.extension.Rd
@@ -7,7 +7,7 @@
 ww.set.file.extension(global_setting = "b.def.ext", default = "png", also_pdf)
 }
 \arguments{
-\item{global_setting}{global file extension setting stored in a global variable. Detault: 'b.def.ext'}
+\item{global_setting}{global file extension setting stored in a global variable. Default: 'b.def.ext'}
 
 \item{default}{Default file extension: png}
 

--- a/man/ww.variable.and.path.exists.Rd
+++ b/man/ww.variable.and.path.exists.Rd
@@ -9,7 +9,7 @@ ww.variable.and.path.exists(path = path_of_report, alt.message = NULL)
 ww.variable.and.path.exists(path = path_of_report, alt.message = NULL)
 }
 \arguments{
-\item{path}{A variable name that might not exist and might point to a non-existent direcotry.}
+\item{path}{A variable name that might not exist and might point to a non-existent directory.}
 
 \item{alt.message}{Alternative message if the variable + path does not exist. FALSE or string.}
 }


### PR DESCRIPTION
## Summary
- fix various spelling mistakes across documentation and helper functions

## Testing
- `R CMD check --no-manual --as-cran` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689331d84108832c9f92e74b7b4cfd19