### PR TITLE
Improve list name printing and rely on implicit return

### DIFF
--- a/R/MarkdownHelpers.R
+++ b/R/MarkdownHelpers.R
@@ -367,7 +367,7 @@ llwrite_list <- function(yourlist, printName = "self") {
     llprint("####", printName)
   }
   for (e in 1:length(yourlist)) {
-    if (is.null(names(yourlist))) {
+    if (!is.null(names(yourlist))) {
       llprint("#####", names(yourlist)[e])
     } else {
       llprint("#####", e)


### PR DESCRIPTION
## Summary
- Ensure `llwrite_list` prints element names when available, otherwise falls back to numeric indices.
- Remove explicit return from `ww.FnP_parser`, relying on R's default implicit return.

## Testing
- `R CMD check .` *(fails: command not found)*
- `apt-get install -y r-base` *(fails: Unable to locate package r-base)*

------
https://chatgpt.com/codex/tasks/task_e_689335c58e84832c965cbf9a2b3a5ca9