### PR TITLE
Honor field separator argument in md.import.table

### DIFF
--- a/R/MarkdownHelpers.R
+++ b/R/MarkdownHelpers.R
@@ -714,7 +714,7 @@ md.import.table <- function(from.file.table,
     read.table(
       from.file.table,
       stringsAsFactors = FALSE,
-      sep = "\t",
+      sep = field.sep,
       header = has.colnames,
       row.names = 1
     )
@@ -722,7 +722,7 @@ md.import.table <- function(from.file.table,
     read.table(
       from.file.table,
       stringsAsFactors = FALSE,
-      sep = "\t",
+      sep = field.sep,
       header = has.colnames
     )
   }


### PR DESCRIPTION
## Summary
- ensure md.import.table respects the user-supplied field separator when reading files

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ef295c1d883239956d7f26998c0c2)